### PR TITLE
feat: integrate Hyperion v2 history API

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -6,8 +6,9 @@ import jwt from "jsonwebtoken"
 
 export async function POST(req: Request) {
   const body = await req.json()
-  const { messages, chainEndpoint: chainEp, walletAccount, llmConfig } = body
+  const { messages, chainEndpoint: chainEp, hyperionEndpoint: hyperionEp, walletAccount, llmConfig } = body
   const chainEndpoint = chainEp || ""
+  const hyperionEndpoint = hyperionEp || ""
 
   let llmProvider = ""
   let llmApiKey = ""
@@ -47,7 +48,7 @@ export async function POST(req: Request) {
   }
 
   const llmModel = createLLMModel(llmProvider, llmApiKey, llmModelName)
-  const tools = createChainTools(chainEndpoint || null)
+  const tools = createChainTools(chainEndpoint || null, hyperionEndpoint || null)
 
   const systemPrompt = `You are an Antelope blockchain explorer assistant. You help users understand and interact with Antelope-based blockchains (EOS, WAX, Telos, etc.).
 
@@ -65,6 +66,8 @@ Guidelines:
 - When you receive a [System: ...] message about a chain or wallet change, introduce yourself briefly (1-2 sentences), mention what chain/account they're on, and suggest a few things you can help with. Don't repeat the system message — just respond naturally as a greeting.
 
 ${chainEndpoint ? "Connected chain endpoint: " + chainEndpoint : "No chain connected — inform the user they should connect to a chain to query on-chain data."}
+
+${hyperionEndpoint ? "Hyperion history API is available. You can query full action history, token transfers, account creation history, token holdings across all contracts, and key-to-account lookups using the get_actions, get_transfers, get_created_accounts, get_creator, get_tokens, and get_key_accounts tools." : ""}
 
 ${walletAccount ? `The user's connected wallet account is: ${walletAccount}. When they say "my account", "my balance", etc., use this account name. When building transactions, use this as the "from" account.` : "No wallet connected."}`
 

--- a/components/chain/chain-selector.tsx
+++ b/components/chain/chain-selector.tsx
@@ -28,7 +28,7 @@ function ChainContent() {
               size="sm"
               className="justify-start"
               disabled={connecting}
-              onClick={() => connect(chain.url, chain.name)}
+              onClick={() => connect(chain.url, chain.name, chain.hyperion)}
             >
               {chainInfo && chainName === chain.name && (
                 <Check className="h-3 w-3 mr-1 text-green-500" />

--- a/components/chat/cards/actions-card.tsx
+++ b/components/chat/cards/actions-card.tsx
@@ -1,0 +1,88 @@
+"use client"
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import { Activity } from "lucide-react"
+
+interface Action {
+  block?: number
+  timestamp?: string
+  contract?: string
+  action?: string
+  actors?: string
+  data?: Record<string, unknown>
+  [key: string]: unknown
+}
+
+interface ActionsCardProps {
+  data: {
+    actions: Action[]
+    total?: { value: number; relation: string }
+  }
+}
+
+export function ActionsCard({ data }: ActionsCardProps) {
+  const { actions, total } = data
+
+  if (!actions || actions.length === 0) {
+    return (
+      <Card className="my-2 max-w-lg">
+        <CardContent className="px-4 py-3 text-sm text-muted-foreground">
+          No actions found
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <Card className="my-2 max-w-lg overflow-hidden">
+      <CardHeader className="pb-2 pt-3 px-4">
+        <CardTitle className="text-sm flex items-center gap-2">
+          <Activity className="h-4 w-4" />
+          Action History
+          {total && (
+            <span className="text-xs text-muted-foreground ml-auto">
+              Showing {actions.length} of {total.value.toLocaleString()}
+            </span>
+          )}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="px-0 pb-0">
+        <div className="overflow-x-auto">
+          <table className="w-full text-xs">
+            <thead>
+              <tr className="border-t">
+                <th className="px-3 py-1.5 text-left font-medium text-muted-foreground">Time</th>
+                <th className="px-3 py-1.5 text-left font-medium text-muted-foreground">Contract</th>
+                <th className="px-3 py-1.5 text-left font-medium text-muted-foreground">Action</th>
+                <th className="px-3 py-1.5 text-left font-medium text-muted-foreground">Actor</th>
+                <th className="px-3 py-1.5 text-left font-medium text-muted-foreground">Data</th>
+              </tr>
+            </thead>
+            <tbody>
+              {actions.map((act, i) => {
+                const ts = act.timestamp || act["@timestamp"] as string | undefined
+                const time = ts ? new Date(ts).toLocaleString() : "—"
+                const dataSummary = act.data
+                  ? Object.entries(act.data).map(([k, v]) => `${k}:${typeof v === "string" ? v : JSON.stringify(v)}`).join(", ")
+                  : "—"
+
+                return (
+                  <tr key={i} className="border-t">
+                    <td className="px-3 py-1.5 whitespace-nowrap text-muted-foreground">{time}</td>
+                    <td className="px-3 py-1.5 whitespace-nowrap">
+                      <Badge variant="outline" className="text-[10px]">{String(act.contract || "—")}</Badge>
+                    </td>
+                    <td className="px-3 py-1.5 whitespace-nowrap font-medium">{String(act.action || "—")}</td>
+                    <td className="px-3 py-1.5 whitespace-nowrap">{String(act.actors || "—")}</td>
+                    <td className="px-3 py-1.5 max-w-[200px] truncate" title={dataSummary}>{dataSummary}</td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/chat/cards/tokens-card.tsx
+++ b/components/chat/cards/tokens-card.tsx
@@ -1,0 +1,74 @@
+"use client"
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import { Coins } from "lucide-react"
+
+interface Token {
+  symbol?: string
+  amount?: number
+  contract?: string
+  precision?: number
+  [key: string]: unknown
+}
+
+interface TokensCardProps {
+  data: {
+    tokens: Token[]
+    account?: string
+  }
+}
+
+export function TokensCard({ data }: TokensCardProps) {
+  const { tokens, account } = data
+
+  if (!tokens || tokens.length === 0) {
+    return (
+      <Card className="my-2 max-w-md">
+        <CardContent className="px-4 py-3 text-sm text-muted-foreground">
+          No tokens found
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <Card className="my-2 max-w-md overflow-hidden">
+      <CardHeader className="pb-2 pt-3 px-4">
+        <CardTitle className="text-sm flex items-center gap-2">
+          <Coins className="h-4 w-4" />
+          Token Holdings
+          {account && (
+            <Badge variant="secondary" className="ml-auto text-xs">{account}</Badge>
+          )}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="px-0 pb-0">
+        <div className="overflow-x-auto">
+          <table className="w-full text-xs">
+            <thead>
+              <tr className="border-t">
+                <th className="px-3 py-1.5 text-left font-medium text-muted-foreground">Symbol</th>
+                <th className="px-3 py-1.5 text-right font-medium text-muted-foreground">Amount</th>
+                <th className="px-3 py-1.5 text-left font-medium text-muted-foreground">Contract</th>
+              </tr>
+            </thead>
+            <tbody>
+              {tokens.map((token, i) => (
+                <tr key={i} className="border-t">
+                  <td className="px-3 py-1.5 whitespace-nowrap font-medium">{String(token.symbol || "—")}</td>
+                  <td className="px-3 py-1.5 whitespace-nowrap text-right font-mono">
+                    {token.amount !== undefined ? Number(token.amount).toLocaleString(undefined, { maximumFractionDigits: token.precision || 4 }) : "—"}
+                  </td>
+                  <td className="px-3 py-1.5 whitespace-nowrap">
+                    <Badge variant="outline" className="text-[10px]">{String(token.contract || "—")}</Badge>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/chat/cards/transfers-card.tsx
+++ b/components/chat/cards/transfers-card.tsx
@@ -1,0 +1,96 @@
+"use client"
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import { ArrowLeftRight, ArrowRight } from "lucide-react"
+
+interface Transfer {
+  from?: string
+  to?: string
+  quantity?: string
+  symbol?: string
+  memo?: string
+  contract?: string
+  timestamp?: string
+  "@timestamp"?: string
+  act?: {
+    data?: { from?: string; to?: string; quantity?: string; memo?: string }
+  }
+  [key: string]: unknown
+}
+
+interface TransfersCardProps {
+  data: {
+    transfers: Transfer[]
+    account?: string
+  }
+}
+
+export function TransfersCard({ data }: TransfersCardProps) {
+  const { transfers, account } = data
+
+  if (!transfers || transfers.length === 0) {
+    return (
+      <Card className="my-2 max-w-lg">
+        <CardContent className="px-4 py-3 text-sm text-muted-foreground">
+          No transfers found
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <Card className="my-2 max-w-lg overflow-hidden">
+      <CardHeader className="pb-2 pt-3 px-4">
+        <CardTitle className="text-sm flex items-center gap-2">
+          <ArrowLeftRight className="h-4 w-4" />
+          Transfer History
+          {account && (
+            <Badge variant="secondary" className="ml-auto text-xs">{account}</Badge>
+          )}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="px-0 pb-0">
+        <div className="overflow-x-auto">
+          <table className="w-full text-xs">
+            <thead>
+              <tr className="border-t">
+                <th className="px-3 py-1.5 text-left font-medium text-muted-foreground">Time</th>
+                <th className="px-3 py-1.5 text-left font-medium text-muted-foreground">From</th>
+                <th className="px-3 py-1.5 text-left font-medium text-muted-foreground"></th>
+                <th className="px-3 py-1.5 text-left font-medium text-muted-foreground">To</th>
+                <th className="px-3 py-1.5 text-left font-medium text-muted-foreground">Amount</th>
+                <th className="px-3 py-1.5 text-left font-medium text-muted-foreground">Memo</th>
+              </tr>
+            </thead>
+            <tbody>
+              {transfers.map((tx, i) => {
+                const actData = tx.act?.data
+                const from = tx.from || actData?.from || "—"
+                const to = tx.to || actData?.to || "—"
+                const quantity = tx.quantity || actData?.quantity || "—"
+                const memo = tx.memo || actData?.memo || ""
+                const ts = tx.timestamp || tx["@timestamp"]
+                const time = ts ? new Date(ts).toLocaleString() : "—"
+                const isOutgoing = account && from === account
+
+                return (
+                  <tr key={i} className="border-t">
+                    <td className="px-3 py-1.5 whitespace-nowrap text-muted-foreground">{time}</td>
+                    <td className={`px-3 py-1.5 whitespace-nowrap ${isOutgoing ? "font-medium" : ""}`}>{from}</td>
+                    <td className="px-1 py-1.5">
+                      <ArrowRight className={`h-3 w-3 ${isOutgoing ? "text-red-500" : "text-green-500"}`} />
+                    </td>
+                    <td className={`px-3 py-1.5 whitespace-nowrap ${!isOutgoing ? "font-medium" : ""}`}>{to}</td>
+                    <td className="px-3 py-1.5 whitespace-nowrap font-medium">{quantity}</td>
+                    <td className="px-3 py-1.5 max-w-[150px] truncate text-muted-foreground" title={memo}>{memo}</td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/chat/chat-panel.tsx
+++ b/components/chat/chat-panel.tsx
@@ -20,7 +20,7 @@ import { ToolResultRenderer } from "./cards/tool-result-renderer"
 
 export function ChatPanel() {
   const { isConfigured, getClientConfig } = useLLM()
-  const { endpoint, chainName } = useChain()
+  const { endpoint, hyperionEndpoint, chainName } = useChain()
   const { accountName } = useWallet()
   const { user } = useAuth()
   const {
@@ -34,13 +34,16 @@ export function ChatPanel() {
   activeConvRef.current = activeConversationId
 
   const endpointRef = useRef(endpoint)
+  const hyperionRef = useRef(hyperionEndpoint)
   const accountRef = useRef(accountName)
   endpointRef.current = endpoint
+  hyperionRef.current = hyperionEndpoint
   accountRef.current = accountName
 
   const customFetch = useCallback(async (input: RequestInfo | URL, init?: RequestInit) => {
     const body = JSON.parse(init?.body as string || "{}")
     body.chainEndpoint = endpointRef.current || ""
+    body.hyperionEndpoint = hyperionRef.current || ""
     body.walletAccount = accountRef.current || ""
     const token = localStorage.getItem("auth_token")
     const headers: Record<string, string> = {

--- a/lib/antelope/hyperion.ts
+++ b/lib/antelope/hyperion.ts
@@ -1,0 +1,148 @@
+export class HyperionClient {
+  constructor(private endpoint: string) {}
+
+  private async query(path: string, params: Record<string, string | number | boolean | undefined>) {
+    const url = new URL(`${this.endpoint}${path}`)
+    for (const [key, value] of Object.entries(params)) {
+      if (value !== undefined) url.searchParams.set(key, String(value))
+    }
+    const res = await fetch(url.toString())
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}))
+      throw new Error(err.message || `Hyperion error: ${res.status}`)
+    }
+    return res.json()
+  }
+
+  // History endpoints
+
+  async getActions(params: {
+    account?: string
+    filter?: string
+    skip?: number
+    limit?: number
+    sort?: "asc" | "desc"
+    after?: string
+    before?: string
+    simple?: boolean
+  }) {
+    return this.query("/v2/history/get_actions", {
+      account: params.account,
+      filter: params.filter,
+      skip: params.skip,
+      limit: params.limit,
+      sort: params.sort,
+      after: params.after,
+      before: params.before,
+      simple: params.simple,
+    })
+  }
+
+  async getTransaction(id: string) {
+    return this.query("/v2/history/get_transaction", { id })
+  }
+
+  async getTransfers(params: {
+    from?: string
+    to?: string
+    symbol?: string
+    contract?: string
+    skip?: number
+    limit?: number
+    after?: string
+    before?: string
+  }) {
+    return this.query("/v2/history/get_transfers", {
+      from: params.from,
+      to: params.to,
+      symbol: params.symbol,
+      contract: params.contract,
+      skip: params.skip,
+      limit: params.limit,
+      after: params.after,
+      before: params.before,
+    })
+  }
+
+  async getCreatedAccounts(account: string) {
+    return this.query("/v2/history/get_created_accounts", { account })
+  }
+
+  async getCreator(account: string) {
+    return this.query("/v2/history/get_creator", { account })
+  }
+
+  async getDeltas(params: {
+    code?: string
+    scope?: string
+    table?: string
+    payer?: string
+  }) {
+    return this.query("/v2/history/get_deltas", {
+      code: params.code,
+      scope: params.scope,
+      table: params.table,
+      payer: params.payer,
+    })
+  }
+
+  async getTransactedAccounts(params: {
+    account: string
+    direction: "in" | "out" | "both"
+    symbol?: string
+    contract?: string
+    min?: number
+    max?: number
+    limit?: number
+  }) {
+    return this.query("/v2/history/get_transacted_accounts", {
+      account: params.account,
+      direction: params.direction,
+      symbol: params.symbol,
+      contract: params.contract,
+      min: params.min,
+      max: params.max,
+      limit: params.limit,
+    })
+  }
+
+  // State endpoints
+
+  async getTokens(account: string) {
+    return this.query("/v2/state/get_tokens", { account })
+  }
+
+  async getKeyAccounts(publicKey: string) {
+    return this.query("/v2/state/get_key_accounts", { public_key: publicKey })
+  }
+
+  async getProposals(params: {
+    proposer?: string
+    account?: string
+    executed?: boolean
+  }) {
+    return this.query("/v2/state/get_proposals", {
+      proposer: params.proposer,
+      account: params.account,
+      executed: params.executed,
+    })
+  }
+
+  async getVoters(params: {
+    producer?: string
+    skip?: number
+    limit?: number
+  }) {
+    return this.query("/v2/state/get_voters", {
+      producer: params.producer,
+      skip: params.skip,
+      limit: params.limit,
+    })
+  }
+
+  // Health
+
+  async getHealth() {
+    return this.query("/v2/health", {})
+  }
+}

--- a/lib/stores/chain-store.tsx
+++ b/lib/stores/chain-store.tsx
@@ -4,23 +4,24 @@ import { createContext, useContext, useState, useCallback, useEffect, ReactNode 
 import { AntelopeClient, ChainInfo } from "@/lib/antelope/client"
 
 const PRESET_CHAINS = [
-  { name: "EOS Mainnet", url: "https://eos.greymass.com" },
-  { name: "Jungle4 Testnet", url: "https://jungle4.greymass.com" },
-  { name: "WAX Mainnet", url: "https://wax.greymass.com" },
-  { name: "Telos Mainnet", url: "https://telos.greymass.com" },
-  { name: "FIO Mainnet", url: "https://fio.greymass.com" },
-  { name: "Libre", url: "https://libre.greymass.com" },
+  { name: "EOS Mainnet", url: "https://eos.greymass.com", hyperion: "https://eos.hyperion.eosrio.io" },
+  { name: "Jungle4 Testnet", url: "https://jungle4.greymass.com", hyperion: "https://jungle.eosusa.io" },
+  { name: "WAX Mainnet", url: "https://wax.greymass.com", hyperion: "https://wax.eosrio.io" },
+  { name: "Telos Mainnet", url: "https://telos.greymass.com", hyperion: "https://mainnet.telos.net" },
+  { name: "FIO Mainnet", url: "https://fio.greymass.com", hyperion: "https://fio.cryptolions.io" },
+  { name: "Libre", url: "https://libre.greymass.com", hyperion: "https://libre.eosusa.io" },
 ]
 
 interface ChainState {
   endpoint: string | null
+  hyperionEndpoint: string | null
   chainInfo: ChainInfo | null
   chainName: string | null
   client: AntelopeClient | null
   presets: typeof PRESET_CHAINS
   connecting: boolean
   error: string | null
-  connect: (endpoint: string, name?: string) => Promise<void>
+  connect: (endpoint: string, name?: string, hyperion?: string) => Promise<void>
   disconnect: () => void
 }
 
@@ -28,13 +29,14 @@ const ChainContext = createContext<ChainState | null>(null)
 
 export function ChainProvider({ children }: { children: ReactNode }) {
   const [endpoint, setEndpoint] = useState<string | null>(null)
+  const [hyperionEndpoint, setHyperionEndpoint] = useState<string | null>(null)
   const [chainInfo, setChainInfo] = useState<ChainInfo | null>(null)
   const [chainName, setChainName] = useState<string | null>(null)
   const [client, setClient] = useState<AntelopeClient | null>(null)
   const [connecting, setConnecting] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
-  const connect = useCallback(async (url: string, name?: string) => {
+  const connect = useCallback(async (url: string, name?: string, hyperion?: string) => {
     setConnecting(true)
     setError(null)
     try {
@@ -44,8 +46,16 @@ export function ChainProvider({ children }: { children: ReactNode }) {
       setChainInfo(info)
       setChainName(name || url)
       setClient(c)
+      // Resolve Hyperion endpoint: explicit param > preset lookup > none
+      const resolvedHyperion = hyperion || PRESET_CHAINS.find((p) => p.url === url)?.hyperion || null
+      setHyperionEndpoint(resolvedHyperion)
       localStorage.setItem("antelope_endpoint", url)
       localStorage.setItem("antelope_chain_name", name || url)
+      if (resolvedHyperion) {
+        localStorage.setItem("antelope_hyperion", resolvedHyperion)
+      } else {
+        localStorage.removeItem("antelope_hyperion")
+      }
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to connect")
     } finally {
@@ -57,24 +67,27 @@ export function ChainProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     const savedEndpoint = localStorage.getItem("antelope_endpoint")
     const savedName = localStorage.getItem("antelope_chain_name")
+    const savedHyperion = localStorage.getItem("antelope_hyperion")
     if (savedEndpoint) {
-      connect(savedEndpoint, savedName || undefined)
+      connect(savedEndpoint, savedName || undefined, savedHyperion || undefined)
     }
   }, [connect])
 
   const disconnect = useCallback(() => {
     setEndpoint(null)
+    setHyperionEndpoint(null)
     setChainInfo(null)
     setChainName(null)
     setClient(null)
     localStorage.removeItem("antelope_endpoint")
     localStorage.removeItem("antelope_chain_name")
+    localStorage.removeItem("antelope_hyperion")
   }, [])
 
   return (
     <ChainContext.Provider
       value={{
-        endpoint, chainInfo, chainName, client,
+        endpoint, hyperionEndpoint, chainInfo, chainName, client,
         presets: PRESET_CHAINS, connecting, error,
         connect, disconnect,
       }}


### PR DESCRIPTION
## Summary
- Add `HyperionClient` class for Hyperion v2 GET-based API endpoints (actions, transfers, creators, tokens, key lookups, health)
- Add 6 new LLM tools: `get_actions`, `get_transfers`, `get_created_accounts`, `get_creator`, `get_tokens`, `get_key_accounts` — only enabled when a Hyperion endpoint is available
- Add 3 new UI cards (`ActionsCard`, `TransfersCard`, `TokensCard`) and inline renderers for creator/created-accounts/key-accounts
- Update chain presets with Hyperion endpoint URLs for all 6 chains, persisted in localStorage

## Test plan
- [ ] Connect to EOS Mainnet and verify `localStorage` has `antelope_hyperion` set
- [ ] Chat: "Show me the last 10 actions for eosio" → ActionsCard renders
- [ ] Chat: "Show token transfers for teamgreymass" → TransfersCard renders
- [ ] Chat: "What accounts did eosio create?" → inline list renders
- [ ] Chat: "Who created teamgreymass?" → inline creator info renders
- [ ] Chat: "What tokens does teamgreymass hold?" → TokensCard renders
- [ ] Chat: "What accounts are associated with this public key: EOS6MR..." → inline list renders
- [ ] Connect via custom endpoint (no preset) → Hyperion tools absent, existing tools still work
- [ ] Switch chains → Hyperion endpoint updates correctly
- [ ] Disconnect → all localStorage keys cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)