### PR TITLE
Context-aware welcome prompts, dismissible tx cards, fix chat refresh

### DIFF
--- a/components/chat/cards/tx-proposal-card.tsx
+++ b/components/chat/cards/tx-proposal-card.tsx
@@ -30,6 +30,7 @@ export function TxProposalCard({ data, onTxError }: TxProposalCardProps) {
   const [signing, setSigning] = useState(false)
   const [txResult, setTxResult] = useState<string | null>(null)
   const [txError, setTxError] = useState<string | null>(null)
+  const [dismissed, setDismissed] = useState(false)
   const [editableActions, setEditableActions] = useState<TxAction[]>(
     () => data.actions.map((a) => ({ ...a, data: { ...a.data } }))
   )
@@ -100,6 +101,14 @@ export function TxProposalCard({ data, onTxError }: TxProposalCardProps) {
     }
   }
 
+  if (dismissed) {
+    return (
+      <div className="my-2 text-xs text-muted-foreground/60 italic">
+        Transaction proposal dismissed
+      </div>
+    )
+  }
+
   return (
     <Card className="my-2 max-w-md border-primary/50">
       <CardHeader className="pb-2 pt-3 px-4">
@@ -109,6 +118,16 @@ export function TxProposalCard({ data, onTxError }: TxProposalCardProps) {
           <Badge variant="outline" className="ml-auto text-xs">
             {txResult ? "Broadcast" : txError ? "Failed" : data.status === "pending_signature" ? "Pending" : data.status}
           </Badge>
+          {!txResult && (
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-6 w-6 shrink-0 text-muted-foreground hover:text-destructive"
+              onClick={() => setDismissed(true)}
+            >
+              <X className="h-3 w-3" />
+            </Button>
+          )}
         </CardTitle>
       </CardHeader>
       <CardContent className="px-4 pb-3 space-y-3">

--- a/components/chat/chat-panel.tsx
+++ b/components/chat/chat-panel.tsx
@@ -288,10 +288,10 @@ export function ChatPanel() {
               <h2 className="text-lg font-semibold">Talk<span className="font-normal">block</span></h2>
               <div className="grid grid-cols-2 gap-2 max-w-md w-full">
                 {[
-                  { label: "Look up an account", query: "Tell me about the eosio account" },
-                  { label: "Check token balances", query: "What tokens does eosio.token hold?" },
-                  { label: "Inspect a contract", query: "Show me the ABI for eosio.token" },
-                  { label: "Get latest block", query: "Show me the latest block" },
+                  { label: "Look up my account", query: accountName ? `Show me details about the ${accountName} account` : "Tell me about the eosio account" },
+                  { label: "Check my token balances", query: accountName ? `What tokens does ${accountName} hold?` : "What tokens does eosio.token hold?" },
+                  { label: "Top block producers", query: "Show me the top block producers" },
+                  { label: "Transfer tokens", query: accountName ? `Build a transfer of 1 unit of the native token from ${accountName} to ` : "Build a transfer of 1 unit of the native token from myaccount to " },
                 ].map((suggestion) => (
                   <button
                     key={suggestion.label}

--- a/lib/stores/chain-store.tsx
+++ b/lib/stores/chain-store.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { createContext, useContext, useState, useCallback, useEffect, ReactNode } from "react"
+import { createContext, useContext, useState, useCallback, useEffect, useMemo, ReactNode } from "react"
 import { AntelopeClient, ChainInfo } from "@/lib/antelope/client"
 
 const PRESET_CHAINS = [
@@ -95,14 +95,14 @@ export function ChainProvider({ children }: { children: ReactNode }) {
     localStorage.removeItem("antelope_hyperion")
   }, [])
 
+  const value = useMemo(() => ({
+    endpoint, hyperionEndpoint, chainInfo, chainName, client,
+    presets: PRESET_CHAINS, connecting, error,
+    connect, disconnect, refreshInfo,
+  }), [endpoint, hyperionEndpoint, chainInfo, chainName, client, connecting, error, connect, disconnect, refreshInfo])
+
   return (
-    <ChainContext.Provider
-      value={{
-        endpoint, hyperionEndpoint, chainInfo, chainName, client,
-        presets: PRESET_CHAINS, connecting, error,
-        connect, disconnect, refreshInfo,
-      }}
-    >
+    <ChainContext.Provider value={value}>
       {children}
     </ChainContext.Provider>
   )


### PR DESCRIPTION
## Summary
- Welcome suggestions use signed-in account name when available
- Transaction proposal cards can be dismissed with X button
- Fix 5-minute chat window refresh caused by global chainInfo updates
- Left panel refreshes chain info locally without triggering global re-renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)