### PR TITLE
fix: first chat message disappearing + remove debug logging

### DIFF
--- a/components/chat/chat-panel.tsx
+++ b/components/chat/chat-panel.tsx
@@ -118,6 +118,10 @@ export function ChatPanel() {
 
   // Load messages when active conversation changes
   useEffect(() => {
+    if (justCreatedRef.current) {
+      justCreatedRef.current = false
+      return
+    }
     if (activeConversationId) {
       loadMessages(activeConversationId).then((msgs) => {
         const chatMessages = msgs.map((m: { role: string; parts: unknown[] }, i: number) => ({
@@ -155,10 +159,14 @@ export function ChatPanel() {
     })
   }, [sendMessage])
 
+  // Track when we just created a conversation so the load effect skips it
+  const justCreatedRef = useRef(false)
+
   // Auto-create conversation on first message send
   const handleSend = useCallback(async (text: string) => {
     setOutOfCredits(false)
     if (!activeConvRef.current) {
+      justCreatedRef.current = true
       const convId = await createConversation(chainName || undefined, endpoint || undefined)
       activeConvRef.current = convId
     }

--- a/lib/llm/tools.ts
+++ b/lib/llm/tools.ts
@@ -154,9 +154,6 @@ export function createChainTools(endpoint: string | null, hyperionEndpoint: stri
         reverse,
       }) => {
         try {
-          const logLine1 = `[${new Date().toISOString()}] [get_table_rows] LLM called with: ${JSON.stringify({ code, table, scope, limit, lower_bound, upper_bound, index_position, key_type, reverse })}\n`
-          console.log(logLine1.trim())
-          require("fs").appendFileSync("/tmp/llm-tool-calls.log", logLine1)
           const result = await client.getTableRows({
             code,
             table,
@@ -168,9 +165,6 @@ export function createChainTools(endpoint: string | null, hyperionEndpoint: stri
             key_type,
             reverse,
           })
-          const logLine2 = `[${new Date().toISOString()}] [get_table_rows] Returned ${result.rows?.length ?? 0} rows\n`
-          console.log(logLine2.trim())
-          require("fs").appendFileSync("/tmp/llm-tool-calls.log", logLine2)
           return {
             code,
             table,
@@ -325,9 +319,6 @@ export function createChainTools(endpoint: string | null, hyperionEndpoint: stri
           .describe("The contract account name (e.g. 'eosio.system', 'eosio.token', 'atomicassets')"),
       }),
       execute: async ({ contract }) => {
-        const guideLog = `[${new Date().toISOString()}] [get_contract_guide] LLM requested guide for: ${contract}\n`
-        console.log(guideLog.trim())
-        require("fs").appendFileSync("/tmp/llm-tool-calls.log", guideLog)
         const guide = getContractGuide(contract, chainName || undefined)
         if (guide) {
           return {


### PR DESCRIPTION
## Summary
- Fix race condition where first user message disappears because `createConversation` triggers `loadMessages` effect that overwrites messages with empty DB result
- Remove debug logging from LLM tools

## Test plan
- [ ] Send first message in a new conversation — verify it stays visible
- [ ] Switch between existing conversations — verify messages load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)