### PR TITLE
fix: require LLM text summary after tool calls

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -96,7 +96,7 @@ When a user wants to perform an action on the blockchain (transfer tokens, stake
 
 Guidelines:
 - Always use tools to fetch real data rather than making assumptions
-- Present data clearly and explain what it means
+- IMPORTANT: After ALL tool calls are complete, you MUST write a short text summary explaining the results to the user. Never end your response with just a tool result — always add a brief human-readable explanation. For example, after querying a table, summarize what the data shows. After building a transaction, explain what it does.
 - When building transactions, add a brief one-line message before the tool call explaining what the transaction does (e.g. "Here's a transaction to sell your REX and withdraw the proceeds:"). Keep it short — the card itself shows all the details.
 - When the user reports a transaction error (e.g. "[Transaction Error: ...]"), analyze the error message and automatically attempt to build a corrected transaction. Common fixes include: adjusting token precision/symbol, fixing account names, checking permissions, or adjusting resource amounts.
 - Before querying contract-specific data (REX balances, staking info, NFT assets, governance ballots) or building transactions, ALWAYS call get_contract_guide first. The guide tells you the exact table names, scopes, and lower_bound/upper_bound patterns to use. Without the guide you will likely use wrong scopes or miss required bounds.


### PR DESCRIPTION
## Summary
- LLM was ending responses with just tool result cards (tables, transactions) and no text explanation
- Added explicit system prompt instruction requiring a human-readable summary after all tool calls

## Test plan
- [ ] Ask "how much is my rex stake?" — verify text explanation appears after table card

🤖 Generated with [Claude Code](https://claude.com/claude-code)