### PR TITLE
Remove dark theme, keep light/dusk/dim

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2,7 +2,7 @@
 @import "tw-animate-css";
 @import "shadcn/tailwind.css";
 
-@custom-variant dark (&:is(.dark *, .dim *, .dusk *));
+@custom-variant dark (&:is(.dim *, .dusk *));
 
 @theme inline {
   --color-background: var(--background);
@@ -80,40 +80,6 @@
   --sidebar-accent-foreground: oklch(0.205 0 0);
   --sidebar-border: oklch(0.922 0 0);
   --sidebar-ring: oklch(0.708 0 0);
-}
-
-.dark {
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
-  --chart-1: oklch(0.488 0.243 264.376);
-  --chart-2: oklch(0.696 0.17 162.48);
-  --chart-3: oklch(0.769 0.188 70.08);
-  --chart-4: oklch(0.627 0.265 303.9);
-  --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.205 0 0);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.269 0 0);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.556 0 0);
 }
 
 .dim {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -33,8 +33,9 @@ export default function RootLayout({
         `}} />
         <script dangerouslySetInnerHTML={{ __html: `
           (function() {
-            var t = localStorage.getItem('theme') || 'dark';
-            var all = ['dark','dim','dusk'];
+            var t = localStorage.getItem('theme') || 'dim';
+            if (t === 'dark') t = 'dim';
+            var all = ['dim','dusk'];
             document.documentElement.classList.remove.apply(document.documentElement.classList, all);
             if (t !== 'light' && all.indexOf(t) !== -1) document.documentElement.classList.add(t);
             var p = new URLSearchParams(window.location.search);

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -15,18 +15,18 @@ import {
 } from "@/components/ui/dialog"
 import { Separator } from "@/components/ui/separator"
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs"
-import { PanelLeft, Sun, Moon, SunMoon, Settings, Link2, Bot } from "lucide-react"
+import { PanelLeft, Sun, SunMoon, Settings, Link2, Bot } from "lucide-react"
 import { useState, useEffect } from "react"
 
-type Theme = "light" | "dusk" | "dim" | "dark"
-const THEME_CYCLE: Theme[] = ["light", "dusk", "dim", "dark"]
+type Theme = "light" | "dusk" | "dim"
+const THEME_CYCLE: Theme[] = ["light", "dusk", "dim"]
 const THEME_LABELS: Record<Theme, string> = {
-  light: "Light", dusk: "Dusk", dim: "Dim", dark: "Dark",
+  light: "Light", dusk: "Dusk", dim: "Dim",
 }
-const DARK_CLASSES: Theme[] = ["dusk", "dim", "dark"]
+const DARK_CLASSES: Theme[] = ["dusk", "dim"]
 
 function useTheme() {
-  const [theme, setTheme] = useState<Theme>("dark")
+  const [theme, setTheme] = useState<Theme>("dim")
   useEffect(() => {
     const el = document.documentElement
     const found = DARK_CLASSES.find((c) => el.classList.contains(c))
@@ -136,7 +136,7 @@ export function Header() {
         <UsageIndicator />
         <WalletButton />
         <Button variant="ghost" size="sm" onClick={theme.cycle} title={`Theme: ${theme.label}`} className="gap-1.5 px-2">
-          {theme.theme === "light" ? <Sun className="h-4 w-4" /> : theme.theme === "dark" ? <Moon className="h-4 w-4" /> : <SunMoon className="h-4 w-4" />}
+          {theme.theme === "light" ? <Sun className="h-4 w-4" /> : <SunMoon className="h-4 w-4" />}
           <span className="text-xs hidden sm:inline">{theme.label}</span>
         </Button>
       </div>


### PR DESCRIPTION
## Summary
- Removed the pure dark theme option from the theme cycle
- Kept light, dusk, and dim modes intact with all `dark:` Tailwind classes still working for dusk/dim
- Users with 'dark' saved in localStorage are automatically migrated to 'dim'
- Default theme changed from dark to dim

## Test plan
- [ ] Verify theme cycles through light → dusk → dim only
- [ ] Confirm dim and dusk modes render correctly with dark variant styles
- [ ] Check that existing users with 'dark' in localStorage get migrated to 'dim'

🤖 Generated with [Claude Code](https://claude.com/claude-code)